### PR TITLE
fix: memory leak introduced in tangerine@1.5.7

### DIFF
--- a/index.js
+++ b/index.js
@@ -1295,103 +1295,101 @@ class Tangerine extends dns.promises.Resolver {
           },
           { once: true }
         );
-      } finally {
-        this.#releaseAbortController(abortController);
-      }
-      // wrap with try/catch because ENODATA shouldn't cause errors
-      try {
-        switch (type) {
-          case 'A': {
-            const result = await this.resolve4(
-              name,
-              { ...options, ttl: true },
-              abortController
-            );
-            return result.map((r) => ({ type, ...r }));
-          }
+        // wrap with try/catch because ENODATA shouldn't cause errors
+        try {
+          switch (type) {
+            case 'A': {
+              const result = await this.resolve4(
+                name,
+                { ...options, ttl: true },
+                abortController
+              );
+              return result.map((r) => ({ type, ...r }));
+            }
 
-          case 'AAAA': {
-            const result = await this.resolve6(
-              name,
-              { ...options, ttl: true },
-              abortController
-            );
-            return result.map((r) => ({ type, ...r }));
-          }
+            case 'AAAA': {
+              const result = await this.resolve6(
+                name,
+                { ...options, ttl: true },
+                abortController
+              );
+              return result.map((r) => ({ type, ...r }));
+            }
 
-          case 'CNAME': {
-            const result = await this.resolveCname(
-              name,
-              options,
-              abortController
-            );
-            return result.map((value) => ({ type, value }));
-          }
+            case 'CNAME': {
+              const result = await this.resolveCname(
+                name,
+                options,
+                abortController
+              );
+              return result.map((value) => ({ type, value }));
+            }
 
-          case 'MX': {
-            const result = await this.resolveMx(name, options, abortController);
-            return result.map((r) => ({ type, ...r }));
-          }
+            case 'MX': {
+              const result = await this.resolveMx(name, options, abortController);
+              return result.map((r) => ({ type, ...r }));
+            }
 
-          case 'NAPTR': {
-            const result = await this.resolveNaptr(
-              name,
-              options,
-              abortController
-            );
-            return result.map((value) => ({ type, value }));
-          }
+            case 'NAPTR': {
+              const result = await this.resolveNaptr(
+                name,
+                options,
+                abortController
+              );
+              return result.map((value) => ({ type, value }));
+            }
 
-          case 'NS': {
-            const result = await this.resolveNs(name, options, abortController);
-            return result.map((value) => ({ type, value }));
-          }
+            case 'NS': {
+              const result = await this.resolveNs(name, options, abortController);
+              return result.map((value) => ({ type, value }));
+            }
 
-          case 'PTR': {
-            const result = await this.resolvePtr(
-              name,
-              options,
-              abortController
-            );
-            return result.map((value) => ({ type, value }));
-          }
+            case 'PTR': {
+              const result = await this.resolvePtr(
+                name,
+                options,
+                abortController
+              );
+              return result.map((value) => ({ type, value }));
+            }
 
-          case 'SOA': {
-            const result = await this.resolveSoa(
-              name,
-              options,
-              abortController
-            );
-            return { type, ...result };
-          }
+            case 'SOA': {
+              const result = await this.resolveSoa(
+                name,
+                options,
+                abortController
+              );
+              return { type, ...result };
+            }
 
-          case 'SRV': {
-            const result = await this.resolveSrv(
-              name,
-              options,
-              abortController
-            );
-            return result.map((value) => ({ type, value }));
-          }
+            case 'SRV': {
+              const result = await this.resolveSrv(
+                name,
+                options,
+                abortController
+              );
+              return result.map((value) => ({ type, value }));
+            }
 
-          case 'TXT': {
-            const result = await this.resolveTxt(
-              name,
-              options,
-              abortController
-            );
-            return result.map((entries) => ({ type, entries }));
-          }
+            case 'TXT': {
+              const result = await this.resolveTxt(
+                name,
+                options,
+                abortController
+              );
+              return result.map((entries) => ({ type, entries }));
+            }
 
-          default: {
-            break;
+            default: {
+              break;
+            }
           }
+        } catch (err) {
+          debug(err);
+
+          if (err.code === dns.NODATA) return;
+          throw err;
         }
-      } catch (err) {
-        debug(err);
-
-        if (err.code === dns.NODATA) return;
-        throw err;
       } finally {
         this.#releaseAbortController(abortController);
       }
@@ -1421,8 +1419,9 @@ class Tangerine extends dns.promises.Resolver {
             this.constructor.ANY_TYPES.length,
           abortController.signal
         );
-      } finally {
+      } catch (err) {
         this.#releaseAbortController(abortController);
+        throw err;
       }
     }
 


### PR DESCRIPTION
As discussed in issue #12 `tangerine@1.5.7` introduced a memory leak by no longer aborting all requests – even those which successfully finished. This created a memory leak because `this.abortControllers` slowly filled up with the `AbortController` instances of queries that finished successfully and were not aborted.

I decided to not simply reintroduce the pre-1.5.7 code because the change was technically a breaking change: Previously, users could expect that the `'abort'` event got always fired – no matter if the query got aborted or if it finished. Since passing a custom `abortController` is part of the library’s API, the change in behavior created a breaking change for users. Of course, the change was accidental and the increased patch version number did not reflect the breaking change.

Since [most users are using `@1.6.0`](https://www.npmjs.com/package/tangerine?activeTab=versions), I decided that the `'abort'` event shall only be sent if the query is actually aborted. This is in line with all versions from `@1.5.7` forward – keeping the behavior that most users expect nowadays. (And it makes logically more sense.) If you publish my changes then I recommend using version `1.6.1`.

Unfortunately, I was not able to run the tests on my system. For some reasons all tests failed even without my changes. Could you do the quality assurance on your side since you know the dev env of your library much better than me?

I can at least say that with careful code review I made the code changes in a way that it is guaranteed that the `AbortController` instances are always removed from `this.abortControllers` while any impact on the existing logic is impossible by working with `try ... catch` and `try ... finally` blocks.